### PR TITLE
CS-2325 - Ship data as soon as records are committed to the DB

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -140,8 +140,14 @@ module ActiveRecord
       end
 
       def commit
-        connection.commit_db_transaction
+        commit_result = connection.commit_db_transaction
+        # commit_db_transaction will return PG::Result upon success, otherwise PG::Error
+        @records.uniq.each {|r| ship_committed_record(r)} if commit_result.is_a?(PG::Result)
         super
+      end
+
+      def ship_committed_record(record)
+        record.ship_data if record.is_a?(GeneralLedgerLineItem)
       end
     end
 


### PR DESCRIPTION
As a last ditch effort to solve our "missing data" dilemma, this modification to ActiveRecord completely bypasses the `after_commit` hook for our shipping processes (right now limited to only GeneralLedgerLineItem records). This modification simply ships a record we're concerned with _immediately_ after we've confirmed a successful commit to the database, as opposed to letting ActiveRecord's callback code execute our shipment. 